### PR TITLE
Improve failure messages when not expecting a list

### DIFF
--- a/lib/rspec/sql.rb
+++ b/lib/rspec/sql.rb
@@ -14,8 +14,9 @@ module RSpec
   Matchers.define :query_database do |expected = nil|
     match do |block|
       @queries = scribe_queries(&block)
+      @matcher = Sql::QueryMatcher.new(@queries, expected)
 
-      matcher.matches?(expected)
+      matcher.matches?
     end
 
     failure_message do |_block|
@@ -56,7 +57,7 @@ module RSpec
     end
 
     def matcher
-      @matcher = Sql::QueryMatcher.new(@queries)
+      @matcher
     end
 
     def scribe_queries(&)

--- a/lib/rspec/sql.rb
+++ b/lib/rspec/sql.rb
@@ -29,7 +29,7 @@ module RSpec
         Expected database queries: #{expected}
         Actual database queries:   #{matcher.actual}
 
-        Diff: #{Expectations.differ.diff_as_object(matcher.actual, expected)}
+        Diff: #{diff(matcher.actual, expected)}
 
         Full query log:
 
@@ -55,6 +55,15 @@ module RSpec
 
     def matcher
       @matcher
+    end
+
+    def diff(actual, expected)
+      if expected.is_a?(Numeric)
+        change = actual - expected
+        format("%+d", change)
+      else
+        Expectations.differ.diff_as_object(actual, expected)
+      end
     end
 
     def scribe_queries(&)

--- a/lib/rspec/sql/query_matcher.rb
+++ b/lib/rspec/sql/query_matcher.rb
@@ -6,6 +6,8 @@ module RSpec
   module Sql
     # Compares expectations with actual queries.
     class QueryMatcher
+      attr_reader :expected
+
       def initialize(queries, expected)
         @queries = queries
         @expected = sanitize_number(expected)
@@ -18,9 +20,11 @@ module RSpec
         actual == expected
       end
 
-      private
+      def actual
+        @actual ||= actual_compared_to_expected
+      end
 
-      attr_reader :expected
+      private
 
       # Support writing: `is_expected.to query_database 5.times`
       def sanitize_number(expected)
@@ -29,10 +33,6 @@ module RSpec
         else
           expected
         end
-      end
-
-      def actual
-        @actual ||= actual_compared_to_expected
       end
 
       def actual_compared_to_expected

--- a/lib/rspec/sql/query_matcher.rb
+++ b/lib/rspec/sql/query_matcher.rb
@@ -6,27 +6,47 @@ module RSpec
   module Sql
     # Compares expectations with actual queries.
     class QueryMatcher
-      def initialize(queries)
+      def initialize(queries, expected)
         @queries = queries
+        @expected = sanitize_number(expected)
       end
 
-      def matches?(expected)
-        if expected.nil?
-          !@queries.empty?
-        elsif expected.is_a?(Integer)
-          @queries.size == expected
-        elsif expected.is_a?(Enumerator) && expected.inspect.match?(/:times>$/)
-          @queries.size == expected.size
-        elsif expected.is_a?(Array)
-          query_names == expected
-        elsif expected.is_a?(Hash)
-          query_summary == expected
+      def matches?
+        # Simple presence validation.
+        return !@queries.empty? if expected.nil?
+
+        actual == expected
+      end
+
+      private
+
+      attr_reader :expected
+
+      # Support writing: `is_expected.to query_database 5.times`
+      def sanitize_number(expected)
+        if expected.is_a?(Enumerator) && expected.inspect.match?(/:times>$/)
+          expected.size
+        else
+          expected
+        end
+      end
+
+      def actual
+        @actual ||= actual_compared_to_expected
+      end
+
+      def actual_compared_to_expected
+        case expected
+        when Integer
+          @queries.size
+        when Array
+          query_names
+        when Hash
+          query_summary
         else
           raise "What are you expecting?"
         end
       end
-
-      private
 
       def query_names
         @queries.map { |q| q[:name] || q[:sql].split.take(2).join(" ") }

--- a/lib/rspec/sql/query_matcher.rb
+++ b/lib/rspec/sql/query_matcher.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "query_summary"
+
+module RSpec
+  module Sql
+    # Compares expectations with actual queries.
+    class QueryMatcher
+      def initialize(queries)
+        @queries = queries
+      end
+
+      def matches?(expected)
+        if expected.nil?
+          !@queries.empty?
+        elsif expected.is_a?(Integer)
+          @queries.size == expected
+        elsif expected.is_a?(Enumerator) && expected.inspect.match?(/:times>$/)
+          @queries.size == expected.size
+        elsif expected.is_a?(Array)
+          query_names == expected
+        elsif expected.is_a?(Hash)
+          query_summary == expected
+        else
+          raise "What are you expecting?"
+        end
+      end
+
+      private
+
+      def query_names
+        @queries.map { |q| q[:name] || q[:sql].split.take(2).join(" ") }
+      end
+
+      def query_summary
+        QuerySummary.new(@queries).summary
+      end
+    end
+  end
+end

--- a/spec/lib/rspec/sql_spec.rb
+++ b/spec/lib/rspec/sql_spec.rb
@@ -84,16 +84,12 @@ RSpec.describe RSpec::Sql do
   end
 
   it "prints user-friendly message expecting a number" do
-    message = error_message { expect { User.last }.to query_database 2 }
+    message = error_message { expect { User.last }.to query_database 0 }
     expect(message).to eq <<~TXT
-      Expected database queries: 2
+      Expected database queries: 0
       Actual database queries:   1
 
-      Diff:
-      @@ -1 +1 @@
-      -2
-      +1
-
+      Diff: +1
 
       Full query log:
 
@@ -107,11 +103,7 @@ RSpec.describe RSpec::Sql do
       Expected database queries: 2
       Actual database queries:   1
 
-      Diff:
-      @@ -1 +1 @@
-      -2
-      +1
-
+      Diff: -1
 
       Full query log:
 

--- a/spec/lib/rspec/sql_spec.rb
+++ b/spec/lib/rspec/sql_spec.rb
@@ -67,16 +67,32 @@ RSpec.describe RSpec::Sql do
     )
   end
 
+  it "prints user-friendly message expecting nothing" do
+    message = error_message { expect { User.last }.not_to query_database }
+    expect(message).to eq <<~TXT
+      Expected no database queries but observed:
+
+      User Load  SELECT "users".* FROM "users" ORDER BY "users"."id" DESC LIMIT ?
+    TXT
+  end
+
+  it "prints user-friendly message expecting something" do
+    message = error_message { expect { nil }.to query_database }
+    expect(message).to eq(
+      "Expected at least one database query but observed none."
+    )
+  end
+
   it "prints user-friendly message expecting a number" do
     message = error_message { expect { User.last }.to query_database 2 }
     expect(message).to eq <<~TXT
       Expected database queries: 2
-      Actual database queries:   ["User Load"]
+      Actual database queries:   1
 
       Diff:
       @@ -1 +1 @@
       -2
-      +["User Load"]
+      +1
 
 
       Full query log:
@@ -89,12 +105,12 @@ RSpec.describe RSpec::Sql do
     message = error_message { expect { User.last }.to query_database 2.times }
     expect(message).to eq <<~TXT
       Expected database queries: 2
-      Actual database queries:   ["User Load"]
+      Actual database queries:   1
 
       Diff:
       @@ -1 +1 @@
       -2
-      +["User Load"]
+      +1
 
 
       Full query log:
@@ -134,12 +150,12 @@ RSpec.describe RSpec::Sql do
     # This message could be better but nobody has asked for it yet.
     expect(message).to eq <<~TXT
       Expected database queries: {:update=>{:user=>1}}
-      Actual database queries:   ["User Load"]
+      Actual database queries:   {:select=>{:users=>1}}
 
       Diff:
       @@ -1 +1 @@
       -:update => {:user=>1},
-      +["User Load"]
+      +:select => {:users=>1},
 
 
       Full query log:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,7 +80,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
The first version of this matcher was just comparing lists of SQL commands. Then we supported more formats like numbers and summary hashes. But the failure messages were still referring to the list of queries and it wasn't easy to see the the difference between expectation and actual outcome. Now we use the same format for failure messages that is used for comparing against expectations.

* Closes #3